### PR TITLE
Hash password before saving it to the database

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,15 @@
       "license": "ISC",
       "dependencies": {
         "@apollo/server": "4.11.0",
-        "@prisma/client": "^5.19.1",
+        "@prisma/client": "5.19.1",
+        "bcryptjs": "^2.4.3",
         "express": "4.19.2",
         "graphql": "16.9.0",
         "graphql-http": "1.22.1"
       },
       "devDependencies": {
         "@eslint/js": "9.9.1",
+        "@types/bcryptjs": "^2.4.6",
         "@types/eslint__js": "8.42.3",
         "@types/node": "22.5.2",
         "eslint": "9.9.1",
@@ -749,6 +751,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
@@ -1347,6 +1356,12 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
     },
     "node_modules/binary-extensions": {

--- a/package.json
+++ b/package.json
@@ -13,12 +13,14 @@
   "dependencies": {
     "@apollo/server": "4.11.0",
     "@prisma/client": "5.19.1",
+    "bcryptjs": "2.4.3",
     "express": "4.19.2",
     "graphql": "16.9.0",
     "graphql-http": "1.22.1"
   },
   "devDependencies": {
     "@eslint/js": "9.9.1",
+    "@types/bcryptjs": "2.4.6",
     "@types/eslint__js": "8.42.3",
     "@types/node": "22.5.2",
     "eslint": "9.9.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { ApolloServer } from '@apollo/server';
 import { GraphQLError } from 'graphql';
 import { startStandaloneServer } from '@apollo/server/standalone';
 import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcryptjs';
 
 const prisma = new PrismaClient();
 
@@ -56,6 +57,10 @@ function validateBirthDate(birthDate: string): boolean {
   return birthDateTime > fromDate && birthDateTime < today;
 }
 
+async function hashPassword(password: string): Promise<string> {
+  return await bcrypt.hash(password, 10);
+}
+
 async function insertUserIntoDB(userData: UserInput): Promise<User> {
   if (!validatePassword(userData.password)) {
     throw new GraphQLError('Password needs to contain at least 6 characters, with at least 1 letter and 1 digit.', {
@@ -77,7 +82,7 @@ async function insertUserIntoDB(userData: UserInput): Promise<User> {
       data: {
         name: userData.name,
         email: userData.email,
-        password: userData.password,
+        password: await hashPassword(userData.password),
         birthDate: new Date(userData.birthDate),
       },
     });


### PR DESCRIPTION
To increase security, the password is hashed before being stored in the database, using `bcrypt`.

This method makes it difficult to discover the password from the database while still allows comparisons with the password.