### PR TITLE
Configure Chai and testing database integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ dist/
 build/
 db/
 
-.env
+*.env

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ dist/
 build/
 db/
 
-*.env
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@apollo/server": "4.11.0",
         "@prisma/client": "5.19.1",
         "bcryptjs": "2.4.3",
+        "dotenv": "16.4.5",
         "express": "4.19.2",
         "graphql": "16.9.0",
         "graphql-http": "1.22.1"
@@ -19,12 +20,13 @@
       "devDependencies": {
         "@eslint/js": "9.9.1",
         "@types/bcryptjs": "2.4.6",
-        "@types/chai": "^4.3.19",
+        "@types/chai": "4.3.19",
         "@types/eslint__js": "8.42.3",
         "@types/mocha": "10.0.7",
         "@types/node": "22.5.2",
         "axios": "1.7.7",
-        "chai": "^5.1.1",
+        "chai": "5.1.1",
+        "dotenv-cli": "^7.4.2",
         "eslint": "9.9.1",
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-prettier": "5.2.1",
@@ -1819,6 +1821,44 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-cli": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-7.4.2.tgz",
+      "integrity": "sha512-SbUj8l61zIbzyhIbg0FwPJq6+wjbzdn9oEtozQpZ6kW2ihCcapKVZj49oCT3oPM+mgQm+itgvUQcG5szxVrZTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "dotenv": "^16.3.0",
+        "dotenv-expand": "^10.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "dotenv": "cli.js"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -3065,6 +3105,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/mocha": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,10 +19,12 @@
       "devDependencies": {
         "@eslint/js": "9.9.1",
         "@types/bcryptjs": "2.4.6",
+        "@types/chai": "^4.3.19",
         "@types/eslint__js": "8.42.3",
         "@types/mocha": "10.0.7",
         "@types/node": "22.5.2",
-        "axios": "^1.7.7",
+        "axios": "1.7.7",
+        "chai": "^5.1.1",
         "eslint": "9.9.1",
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-prettier": "5.2.1",
@@ -771,6 +773,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "4.3.19",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.19.tgz",
+      "integrity": "sha512-2hHHvQBVE2FiSK4eN0Br6snX9MtolHaTo/batnLjlGRhoQzlCL61iVpxoqO7SfFyOw+P/pwv+0zNHzKoGWz9Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -1356,6 +1365,16 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async-retry": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
@@ -1515,6 +1534,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/chai": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.1.tgz",
+      "integrity": "sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1530,6 +1566,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -1699,6 +1745,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -2363,6 +2419,16 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
@@ -2881,6 +2947,16 @@
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
       "license": "Apache-2.0"
     },
+    "node_modules/loupe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.1.tgz",
+      "integrity": "sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -3383,6 +3459,16 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picomatch": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,13 @@
   "main": "dist/index.js",
   "scripts": {
     "compile": "tsc",
+    "docker:up": "docker compose up -d",
+    "docker:stop": "docker compose stop",
     "start": "npm run compile && node ./dist/src/index.js",
     "dev": "npm run compile && nodemon",
     "lint": "eslint .",
-    "test": "npm run compile && mocha 'dist/test/**/*.js'"
+    "migrate-test": "dotenv -e test.env -- prisma migrate dev --name test",
+    "test": "npm run compile && dotenv -e test.env -- mocha 'dist/test/**/*.js'"
   },
   "author": "Pedro Martins Dietrich",
   "license": "ISC",
@@ -16,6 +19,7 @@
     "@apollo/server": "4.11.0",
     "@prisma/client": "5.19.1",
     "bcryptjs": "2.4.3",
+    "dotenv": "16.4.5",
     "express": "4.19.2",
     "graphql": "16.9.0",
     "graphql-http": "1.22.1"
@@ -29,6 +33,7 @@
     "@types/node": "22.5.2",
     "axios": "1.7.7",
     "chai": "5.1.1",
+    "dotenv-cli": "7.4.2",
     "eslint": "9.9.1",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-prettier": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
   "devDependencies": {
     "@eslint/js": "9.9.1",
     "@types/bcryptjs": "2.4.6",
+    "@types/chai": "4.3.19",
     "@types/eslint__js": "8.42.3",
     "@types/mocha": "10.0.7",
     "@types/node": "22.5.2",
     "axios": "1.7.7",
+    "chai": "5.1.1",
     "eslint": "9.9.1",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-prettier": "5.2.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { startDatabase, startServer } from './server.js';
+import { initializeDatabaseInstance, startServer } from './server.js';
 
-startDatabase();
+initializeDatabaseInstance();
 const { url } = await startServer(parseInt(process.env.SERVER_PORT));
 console.log(`Server ready at: ${url}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import { startServer } from './server.js';
+import { startDatabase, startServer } from './server.js';
 
-const { url } = await startServer(4000);
+startDatabase();
+const { url } = await startServer(parseInt(process.env.SERVER_PORT));
 console.log(`Server ready at: ${url}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,7 @@ import bcrypt from 'bcryptjs';
 
 export let prisma: PrismaClient;
 
-export const startDatabase = (): void => {
+export const initializeDatabaseInstance = (): void => {
   prisma = new PrismaClient();
 };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,11 @@ import { startStandaloneServer } from '@apollo/server/standalone';
 import { PrismaClient } from '@prisma/client';
 import bcrypt from 'bcryptjs';
 
-const prisma = new PrismaClient();
+export let prisma: PrismaClient;
+
+export const startDatabase = (): void => {
+  prisma = new PrismaClient();
+};
 
 const typeDefs = `#graphql
   type Query {

--- a/test.env
+++ b/test.env
@@ -1,0 +1,3 @@
+DATABASE_URL="postgresql://pedro-dietrich-onboard:postgres-local@localhost:5433/pedro-dietrich-onboard-test?schema=public"
+SERVER_PORT=4001
+NODE_ENV=test

--- a/test/server.ts
+++ b/test/server.ts
@@ -1,5 +1,5 @@
-import assert from 'assert';
 import axios from 'axios';
+import { expect } from 'chai';
 import { ApolloServer } from '@apollo/server';
 
 import { startServer } from '../src/server.js';
@@ -25,7 +25,7 @@ describe('Hello API', function () {
           }
         `,
       });
-      assert.equal(response.data.data.hello, 'Hello World!');
+      expect(response.data.data.hello).to.be.eq('Hello World!');
     });
   });
 });

--- a/test/server.ts
+++ b/test/server.ts
@@ -2,21 +2,41 @@ import axios from 'axios';
 import { expect } from 'chai';
 import { ApolloServer } from '@apollo/server';
 
-import { startServer } from '../src/server.js';
+import { startDatabase, startServer, prisma } from '../src/server.js';
 
-describe('Hello API', function () {
+describe('Onboard server', function () {
   let server: ApolloServer;
   let url: string;
 
   before(async function () {
-    ({ server, url } = await startServer(4001));
+    startDatabase();
+    ({ server, url } = await startServer(parseInt(process.env.SERVER_PORT)));
   });
 
   after(async function () {
     await server.stop();
   });
 
-  describe('#hello', function () {
+  afterEach(async function () {
+    await prisma.user.deleteMany({});
+  });
+
+  describe('Database connection', function () {
+    it('should be connected to the database through Prisma', async function () {
+      const user = await prisma.user.create({
+        data: {
+          name: 'Test User',
+          email: 'test@user.com',
+          password: 'test_password',
+          birthDate: new Date('2000-01-01'),
+        },
+      });
+
+      expect(user).not.to.be.eq(null);
+    });
+  });
+
+  describe('Hello query', function () {
     it('should fetch the response "Hello World!"', async function () {
       const response = await axios.post(url, {
         query: `#graphql

--- a/test/server.ts
+++ b/test/server.ts
@@ -2,14 +2,14 @@ import axios from 'axios';
 import { expect } from 'chai';
 import { ApolloServer } from '@apollo/server';
 
-import { startDatabase, startServer, prisma } from '../src/server.js';
+import { initializeDatabaseInstance, startServer, prisma } from '../src/server.js';
 
 describe('Onboard server', function () {
   let server: ApolloServer;
   let url: string;
 
   before(async function () {
-    startDatabase();
+    initializeDatabaseInstance();
     ({ server, url } = await startServer(parseInt(process.env.SERVER_PORT)));
   });
 


### PR DESCRIPTION
When running `npm test`, the `test.env` file will be used to fetch the environment variables, instead of the `.env` (used for development).

A test case for checking the connection with the DB has been added, by creating an user directly in the database using **Prisma**.
This will be replaced by proper query/mutation tests later.