### PR TITLE
Require JWT for create user mutation

### DIFF
--- a/src/server-context.ts
+++ b/src/server-context.ts
@@ -1,0 +1,26 @@
+import jwt from 'jsonwebtoken';
+
+export interface TokenInterface {
+  userId: number;
+  iat: number;
+  exp: number;
+}
+
+export const serverContext = async function ({ req }): Promise<{ userId: number }> {
+  const { operationName } = req.body;
+  if (operationName === 'LoginMutation') {
+    return { userId: 0 };
+  }
+
+  const token = req.headers.authorization;
+  if (!token) {
+    throw new Error('Authentication token missing.');
+  }
+
+  try {
+    const decoded = jwt.verify(token, process.env.TOKEN_KEY) as TokenInterface;
+    return { userId: decoded.userId };
+  } catch (err) {
+    throw new Error(`Invalid token.\n${err}`);
+  }
+};

--- a/src/server-context.ts
+++ b/src/server-context.ts
@@ -1,5 +1,9 @@
 import jwt from 'jsonwebtoken';
-import { GraphQLError } from 'graphql';
+
+export interface AuthenticationResult {
+  isAuthenticated: boolean;
+  userId: number;
+}
 
 export interface TokenInterface {
   userId: number;
@@ -7,25 +11,16 @@ export interface TokenInterface {
   exp: number;
 }
 
-export const serverContext = async function ({ req }): Promise<{ userId: number }> {
-  const { operationName } = req.body;
-  if (operationName === 'LoginMutation') {
-    return { userId: 0 };
-  }
-
+export const serverContext = async function ({ req }): Promise<{ authResult: AuthenticationResult }> {
   const token = req.headers.authorization;
   if (!token) {
-    throw new GraphQLError('Authentication token missing.', {
-      extensions: { code: 'UNAUTHENTICATED', http: { status: 200 } },
-    });
+    return { authResult: { isAuthenticated: false, userId: null } };
   }
 
   try {
     const decoded = jwt.verify(token, process.env.TOKEN_KEY) as TokenInterface;
-    return { userId: decoded.userId };
-  } catch (err) {
-    throw new GraphQLError(`Invalid token.\n${err}`, {
-      extensions: { code: 'UNAUTHENTICATED', http: { status: 200 } },
-    });
+    return { authResult: { isAuthenticated: true, userId: decoded.userId } };
+  } catch {
+    return { authResult: { isAuthenticated: false, userId: null } };
   }
 };

--- a/src/server-context.ts
+++ b/src/server-context.ts
@@ -1,4 +1,5 @@
 import jwt from 'jsonwebtoken';
+import { GraphQLError } from 'graphql';
 
 export interface TokenInterface {
   userId: number;
@@ -14,13 +15,17 @@ export const serverContext = async function ({ req }): Promise<{ userId: number 
 
   const token = req.headers.authorization;
   if (!token) {
-    throw new Error('Authentication token missing.');
+    throw new GraphQLError('Authentication token missing.', {
+      extensions: { code: 'UNAUTHENTICATED', http: { status: 200 } },
+    });
   }
 
   try {
     const decoded = jwt.verify(token, process.env.TOKEN_KEY) as TokenInterface;
     return { userId: decoded.userId };
   } catch (err) {
-    throw new Error(`Invalid token.\n${err}`);
+    throw new GraphQLError(`Invalid token.\n${err}`, {
+      extensions: { code: 'UNAUTHENTICATED', http: { status: 200 } },
+    });
   }
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import { PrismaClient } from '@prisma/client';
 import { startStandaloneServer } from '@apollo/server/standalone';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 
+import { serverContext } from './server-context.js';
 import { typeDefs, User, UserInput, LoginInput, Authentication } from './typedefs.js';
 
 export interface DatabaseUserData {
@@ -135,6 +136,7 @@ export const startServer = async (port: number): Promise<{ server: ApolloServer;
 
   const { url } = await startStandaloneServer(server, {
     listen: { port: port },
+    context: serverContext,
   });
 
   return { server: server, url: url };

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,7 @@ import { PrismaClient } from '@prisma/client';
 import { startStandaloneServer } from '@apollo/server/standalone';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 
-import { serverContext } from './server-context.js';
+import { serverContext, AuthenticationResult } from './server-context.js';
 import { typeDefs, User, UserInput, LoginInput, Authentication } from './typedefs.js';
 
 export interface DatabaseUserData {
@@ -114,12 +114,22 @@ async function login(loginInput: LoginInput): Promise<Authentication> {
   throw new ServerErrorGQL(400, 'Incorrect e-mail or password.', 'The credentials are incorrect. Try again.');
 }
 
+function verifyUserID(authResult: AuthenticationResult): void {
+  if (!authResult.isAuthenticated || !authResult.userId) {
+    throw new ServerErrorGQL(401, 'Unauthenticated user.', 'The JWT is either missing or invalid.');
+  }
+}
+
 const resolvers = {
   Query: {
-    hello: () => 'Hello World!',
+    hello: (_, __, context) => {
+      verifyUserID(context.authResult);
+      return 'Hello World!';
+    },
   },
   Mutation: {
-    createUser: async (_, args: { user: UserInput }): Promise<User> => {
+    createUser: async (_, args: { user: UserInput }, context): Promise<User> => {
+      verifyUserID(context.authResult);
       return insertUserIntoDB(args.user);
     },
     login: async (_, args: { loginInput: LoginInput }): Promise<Authentication> => {

--- a/test/login.ts
+++ b/test/login.ts
@@ -4,14 +4,9 @@ import jwt from 'jsonwebtoken';
 import { expect } from 'chai';
 import { ApolloServer } from '@apollo/server';
 
+import { TokenInterface } from '../src/server-context.js';
 import { LoginInput, UserInput, User } from '../src/typedefs.js';
 import { initializeDatabaseInstance, prisma, startServer, DatabaseUserData } from '../src/server.js';
-
-interface TokenInterface {
-  userId: number;
-  iat: number;
-  exp: number;
-}
 
 describe('Login API', function () {
   let server: ApolloServer;

--- a/test/server.ts
+++ b/test/server.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
 import { expect } from 'chai';
 import { ApolloServer } from '@apollo/server';
 
@@ -12,7 +13,8 @@ describe('Onboard server API', function () {
 
   before(async function () {
     initializeDatabaseInstance();
-    ({ server, url } = await startServer(parseInt(process.env.SERVER_PORT)));
+    ({ server, url } = await startServer(+process.env.SERVER_PORT));
+    axios.defaults.headers.authorization = jwt.sign({ userId: 1 }, process.env.TOKEN_KEY, { expiresIn: '30m' });
   });
 
   after(async function () {
@@ -48,6 +50,8 @@ describe('Onboard server API', function () {
         password: 'password123',
         birthDate: '2000-01-01',
       };
+
+      axios.defaults.headers.authorization = jwt.sign({ userId: 1 }, process.env.TOKEN_KEY, { expiresIn: '30m' });
     });
 
     afterEach(async function () {
@@ -86,6 +90,26 @@ describe('Onboard server API', function () {
         name: userInput.name,
         email: userInput.email,
         birthDate: new Date(userInput.birthDate).getTime().toString(),
+      });
+    });
+
+    it('should fail to create user without valid JWT', async function () {
+      axios.defaults.headers.authorization = '';
+
+      const previousUserCount = await prisma.user.count();
+      const response = await axios.post(url, createUserMutation);
+      const currentUserCount = await prisma.user.count();
+
+      expect(currentUserCount).to.be.eq(previousUserCount);
+      expect(response.data).to.be.deep.eq({
+        errors: [
+          {
+            message: 'Authentication token missing.',
+            extensions: {
+              code: 'UNAUTHENTICATED',
+            },
+          },
+        ],
       });
     });
 

--- a/test/server.ts
+++ b/test/server.ts
@@ -102,12 +102,18 @@ describe('Onboard server API', function () {
 
       expect(currentUserCount).to.be.eq(previousUserCount);
       expect(response.data).to.be.deep.eq({
+        data: {
+          createUser: null,
+        },
         errors: [
           {
-            message: 'Authentication token missing.',
+            message: 'Unauthenticated user.',
             extensions: {
-              code: 'UNAUTHENTICATED',
+              code: 'INTERNAL_SERVER_ERROR',
+              additionalInfo: 'The JWT is either missing or invalid.',
             },
+            locations: [{ column: 9, line: 3 }],
+            path: ['createUser'],
           },
         ],
       });


### PR DESCRIPTION
A JWT verification was added to check for a valid JWT before handling any request to the server. except for the `login` mutation.