### PR TITLE
Format GraphQL error messages

### DIFF
--- a/src/server-error.ts
+++ b/src/server-error.ts
@@ -1,0 +1,36 @@
+import { GraphQLError } from 'graphql';
+import { unwrapResolverError } from '@apollo/server/errors';
+
+export class ServerErrorGQL extends GraphQLError {
+  public constructor(
+    public code: number,
+    message: string,
+    public additionalInfo?: string,
+  ) {
+    super(message);
+  }
+}
+
+export interface ServerErrorInterface {
+  code: number;
+  message: string;
+  additionalInfo?: string;
+}
+
+export const formatError = function (formattedError: GraphQLError, error: unknown): ServerErrorInterface {
+  const err = unwrapResolverError(error) as Error;
+
+  if (err instanceof ServerErrorGQL) {
+    return {
+      code: err.code,
+      message: err.message,
+      additionalInfo: err.additionalInfo,
+    };
+  }
+
+  return {
+    code: 500,
+    message: 'Internal server error.',
+    additionalInfo: 'An unhandled error has ocurred in the server.',
+  };
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,11 +1,11 @@
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
-import { GraphQLError } from 'graphql';
 import { ApolloServer } from '@apollo/server';
 import { PrismaClient } from '@prisma/client';
 import { startStandaloneServer } from '@apollo/server/standalone';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 
+import { ServerErrorGQL, formatError } from './server-error.js';
 import { serverContext, AuthenticationResult } from './server-context.js';
 import {
   typeDefs,
@@ -33,15 +33,6 @@ export let prisma: PrismaClient;
 export const initializeDatabaseInstance = (): void => {
   prisma = new PrismaClient();
 };
-
-class ServerErrorGQL extends GraphQLError {
-  public code: number;
-
-  public constructor(code: number, message: string, additionalInfo: string) {
-    super(message, { extensions: { additionalInfo: additionalInfo } });
-    this.code = code;
-  }
-}
 
 async function getUser(userId: GetUserInput): Promise<User> {
   let user: User;
@@ -201,6 +192,7 @@ export const startServer = async (port: number): Promise<{ server: ApolloServer;
   const server = new ApolloServer({
     typeDefs,
     resolvers,
+    formatError,
   });
 
   const { url } = await startStandaloneServer(server, {

--- a/test/login.ts
+++ b/test/login.ts
@@ -136,13 +136,9 @@ describe('Login API', function () {
         },
         errors: [
           {
+            code: 400,
             message: 'Incorrect e-mail or password.',
-            extensions: {
-              code: 'INTERNAL_SERVER_ERROR',
-              additionalInfo: 'The credentials are incorrect. Try again.',
-            },
-            path: ['login'],
-            locations: [{ column: 9, line: 3 }],
+            additionalInfo: 'The credentials are incorrect. Try again.',
           },
         ],
       });
@@ -165,13 +161,9 @@ describe('Login API', function () {
         },
         errors: [
           {
+            code: 400,
             message: 'Incorrect e-mail or password.',
-            extensions: {
-              code: 'INTERNAL_SERVER_ERROR',
-              additionalInfo: 'The credentials are incorrect. Try again.',
-            },
-            path: ['login'],
-            locations: [{ column: 9, line: 3 }],
+            additionalInfo: 'The credentials are incorrect. Try again.',
           },
         ],
       });

--- a/test/server.ts
+++ b/test/server.ts
@@ -107,13 +107,9 @@ describe('User API', function () {
         },
         errors: [
           {
+            code: 401,
             message: 'Unauthenticated user.',
-            extensions: {
-              code: 'INTERNAL_SERVER_ERROR',
-              additionalInfo: 'The JWT is either missing or invalid.',
-            },
-            locations: [{ column: 9, line: 3 }],
-            path: ['createUser'],
+            additionalInfo: 'The JWT is either missing or invalid.',
           },
         ],
       });
@@ -138,13 +134,9 @@ describe('User API', function () {
         },
         errors: [
           {
+            code: 400,
             message: 'E-mail is already in use.',
-            extensions: {
-              code: 'INTERNAL_SERVER_ERROR',
-              additionalInfo: 'The e-mail must be unique, and the one received is already present in the database.',
-            },
-            locations: [{ column: 9, line: 3 }],
-            path: ['createUser'],
+            additionalInfo: 'The e-mail must be unique, and the one received is already present in the database.',
           },
         ],
       });
@@ -168,13 +160,9 @@ describe('User API', function () {
         },
         errors: [
           {
+            code: 400,
             message: 'Invalid password.',
-            extensions: {
-              code: 'INTERNAL_SERVER_ERROR',
-              additionalInfo: 'Password needs to contain at least 6 characters, with at least 1 letter and 1 digit.',
-            },
-            locations: [{ column: 9, line: 3 }],
-            path: ['createUser'],
+            additionalInfo: 'Password needs to contain at least 6 characters, with at least 1 letter and 1 digit.',
           },
         ],
       });
@@ -198,13 +186,9 @@ describe('User API', function () {
         },
         errors: [
           {
+            code: 400,
             message: 'Unreasonable birth date detected.',
-            extensions: {
-              code: 'INTERNAL_SERVER_ERROR',
-              additionalInfo: 'The birth date must be between the year 1900 and the current date.',
-            },
-            locations: [{ column: 9, line: 3 }],
-            path: ['createUser'],
+            additionalInfo: 'The birth date must be between the year 1900 and the current date.',
           },
         ],
       });
@@ -280,13 +264,9 @@ describe('User API', function () {
         },
         errors: [
           {
+            code: 404,
             message: 'User does not exist.',
-            extensions: {
-              code: 'INTERNAL_SERVER_ERROR',
-              additionalInfo: 'No user with the specified ID could be found.',
-            },
-            locations: [{ column: 9, line: 3 }],
-            path: ['user'],
+            additionalInfo: 'No user with the specified ID could be found.',
           },
         ],
       });
@@ -317,13 +297,9 @@ describe('User API', function () {
         },
         errors: [
           {
+            code: 401,
             message: 'Unauthenticated user.',
-            extensions: {
-              code: 'INTERNAL_SERVER_ERROR',
-              additionalInfo: 'The JWT is either missing or invalid.',
-            },
-            locations: [{ column: 9, line: 3 }],
-            path: ['user'],
+            additionalInfo: 'The JWT is either missing or invalid.',
           },
         ],
       });
@@ -474,13 +450,9 @@ describe('User API', function () {
         data: null,
         errors: [
           {
+            code: 401,
             message: 'Unauthenticated user.',
-            extensions: {
-              code: 'INTERNAL_SERVER_ERROR',
-              additionalInfo: 'The JWT is either missing or invalid.',
-            },
-            locations: [{ column: 9, line: 3 }],
-            path: ['users'],
+            additionalInfo: 'The JWT is either missing or invalid.',
           },
         ],
       });


### PR DESCRIPTION
The GraphQL error messages now use a `formatError` to customize unsuccessful responses.

The format contains a `code` (uses the HTTP codes), a `message` and an optional `additionalInfo` for further details of the error.