### PR TITLE
Create `Address` table and integrate to server

### DIFF
--- a/prisma/migrations/20240911192336_added_address_table/migration.sql
+++ b/prisma/migrations/20240911192336_added_address_table/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "Address" (
+    "id" SERIAL NOT NULL,
+    "cep" INTEGER NOT NULL,
+    "street" TEXT NOT NULL,
+    "streetNumber" INTEGER NOT NULL,
+    "complement" INTEGER,
+    "neighborhood" TEXT NOT NULL,
+    "city" TEXT NOT NULL,
+    "state" TEXT NOT NULL,
+    "userId" INTEGER NOT NULL,
+
+    CONSTRAINT "Address_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Address" ADD CONSTRAINT "Address_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,6 +13,20 @@ model User {
   name      String
   password  String
   birthDate DateTime
+  addresses Address[]
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+}
+
+model Address {
+  id            Int @id @default(autoincrement())
+  cep           Int
+  street        String
+  streetNumber  Int
+  complement    Int?
+  neighborhood  String
+  city          String
+  state         String
+  user          User @relation(fields: [userId], references: [id])
+  userId        Int
 }

--- a/src/typedefs.ts
+++ b/src/typedefs.ts
@@ -8,11 +8,22 @@ export const typeDefs = `#graphql
     offset: Int = 0
   }
 
+  input AddressInput {
+    cep: Int!
+    street: String!
+    streetNumber: Int!
+    complement: Int
+    neighborhood: String!
+    city: String!
+    state: String!
+  }
+
   input UserInput {
     name: String!
     email: String!
     password: String!
     birthDate: String!
+    addresses: [AddressInput!]
   }
 
   input LoginInput {
@@ -26,6 +37,7 @@ export const typeDefs = `#graphql
     name: String!
     email: String!
     birthDate: String!
+    addresses: [Address]!
   }
 
   type UserList {
@@ -33,6 +45,18 @@ export const typeDefs = `#graphql
     totalUsers: Int!
     offset: Int!
     lastPage: Boolean!
+  }
+
+  type Address {
+    id: ID!
+    cep: Int!
+    street: String!
+    streetNumber: Int!
+    complement: Int
+    neighborhood: String!
+    city: String!
+    state: String!
+    user: User!
   }
 
   type Authentication {
@@ -66,6 +90,17 @@ export interface UserInput {
   email: string;
   password: string;
   birthDate: string;
+  addresses?: AddressInput[];
+}
+
+export interface AddressInput {
+  cep: number;
+  street: string;
+  streetNumber: number;
+  complement?: number;
+  neighborhood: string;
+  city: string;
+  state: string;
 }
 
 export interface LoginInput {
@@ -79,6 +114,7 @@ export interface User {
   name: string;
   email: string;
   birthDate: Date;
+  addresses?: Address[];
 }
 
 export interface UserList {
@@ -86,6 +122,18 @@ export interface UserList {
   totalUsers: number;
   offset: number;
   lastPage: boolean;
+}
+
+export interface Address {
+  id: number;
+  cep: number;
+  street: string;
+  streetNumber: number;
+  complement?: number;
+  neighborhood: string;
+  city: string;
+  state: string;
+  userId: number;
 }
 
 export interface Authentication {


### PR DESCRIPTION
A table for addresses has been created, related to the `User` table. An user can have multiple addresses, while an address must have only one user (one-to-many relationship).

The GraphQL queries and mutations have been updated to support those changes.